### PR TITLE
sklearn.cross_validation is deprecated

### DIFF
--- a/pyfm/pylibfm.py
+++ b/pyfm/pylibfm.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn import cross_validation
+from sklearn.model_selection import train_test_split
 import random
 from pyfm_fast import FM_fast, CSRDataset
 
@@ -173,7 +173,7 @@ class FM:
         # use sklearn to create a validation dataset for lambda updates
         if self.verbose == True:
             print("Creating validation dataset of %.2f of training for adaptive regularization" % self.validation_size)
-        X_train, validation, train_labels, validation_labels = cross_validation.train_test_split(
+        X_train, validation, train_labels, validation_labels = train_test_split(
             X, y, test_size=self.validation_size)
         self.num_attribute = X_train.shape[1]
 


### PR DESCRIPTION
Every time you load the package you can see the deprecation warning. In future versions of scikit-learn 
the cross_validation will be deprecated.
With this pull request I suggest the change to be compatible with future versions of scikit-learn.