### PR TITLE
Implement the Pickle interface for FM_fast

### DIFF
--- a/pyfm/pylibfm.py
+++ b/pyfm/pylibfm.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn import cross_validation
+from sklearn.model_selection import train_test_split
 import random
 from pyfm_fast import FM_fast, CSRDataset
 
@@ -173,7 +173,7 @@ class FM:
         # use sklearn to create a validation dataset for lambda updates
         if self.verbose == True:
             print("Creating validation dataset of %.2f of training for adaptive regularization" % self.validation_size)
-        X_train, validation, train_labels, validation_labels = cross_validation.train_test_split(
+        X_train, validation, train_labels, validation_labels = train_test_split(
             X, y, test_size=self.validation_size)
         self.num_attribute = X_train.shape[1]
 


### PR DESCRIPTION
Without this change, attempting to pickle the model will result in an error due to the FM_fast Class lacking a proper implementation of the pickle interface. This PR implements it and removes a few unnecessary spaces. Also attributes of the class are made public because if not pickle has no access to them.

The models can be potentially quite large, over 4GB depending on how many features you use. So I recommend using joblib instead of pickle.